### PR TITLE
Handle Reader bounds safely

### DIFF
--- a/core/core_test.mbt
+++ b/core/core_test.mbt
@@ -170,3 +170,19 @@ test "default metadata settings" {
   inspect(ms.printer_orientation, content="")
   inspect(ms.printer_d2d_bmp, content="")
 }
+
+///|
+/// Reader が範囲外アクセスでパニックしないことを確認
+test "reader handles short data gracefully" {
+  let reader = Reader::new(data=Bytes::from_array([1.to_byte(), 2.to_byte()]))
+
+  // 読み取り回数が残りより多くても例外にならない
+  let _ = reader.read_dword()
+  let trailing = reader.read_byte()
+  inspect(trailing, content="0")
+
+  // 不足分を読み込もうとしてもポインタが進むことを確認
+  let bytes = reader.read_bytes(n=5)
+  inspect(bytes.length(), content="0")
+  inspect(reader.position(), content="2")
+}

--- a/core/core_test.mbt
+++ b/core/core_test.mbt
@@ -174,12 +174,12 @@ test "default metadata settings" {
 ///|
 /// Reader が範囲外アクセスでパニックしないことを確認
 test "reader handles short data gracefully" {
-  let reader = Reader::new(data=Bytes::from_array([1.to_byte(), 2.to_byte()]))
+  let reader = Reader::new(data = Bytes::from_array([1U.to_byte(), 2U.to_byte()]))
 
   // 読み取り回数が残りより多くても例外にならない
   let _ = reader.read_dword()
   let trailing = reader.read_byte()
-  inspect(trailing, content="0")
+  inspect(trailing, content="b'\\x00'")
 
   // 不足分を読み込もうとしてもポインタが進むことを確認
   let bytes = reader.read_bytes(n=5)

--- a/core/reader.mbt
+++ b/core/reader.mbt
@@ -39,6 +39,10 @@ pub fn Reader::remaining(self : Reader) -> Int {
 ///|
 /// 1バイト読み込んで位置を進める
 pub fn Reader::read_byte(self : Reader) -> Byte {
+  if self.pos >= self.data.length() {
+    self.pos = self.data.length()
+    return 0.to_byte()
+  }
   let b = self.data[self.pos]
   self.pos = self.pos + 1
   b
@@ -100,11 +104,13 @@ pub fn Reader::skip(self : Reader, n~ : Int) -> Unit {
 /// nバイト読み込む
 /// データが不足している場合は空のBytesを返す
 pub fn Reader::read_bytes(self : Reader, n~ : Int) -> Bytes {
-  if self.remaining() < n {
+  let available = if n > self.remaining() { self.remaining() } else { n }
+  if available <= 0 {
+    self.pos = self.data.length()
     return Bytes::from_array([])
   }
   let start = self.pos
-  let end = self.pos + n
+  let end = self.pos + available
   self.pos = end
   Bytes::from_array(self.data[start:end])
 }

--- a/core/reader.mbt
+++ b/core/reader.mbt
@@ -41,7 +41,7 @@ pub fn Reader::remaining(self : Reader) -> Int {
 pub fn Reader::read_byte(self : Reader) -> Byte {
   if self.pos >= self.data.length() {
     self.pos = self.data.length()
-    return 0.to_byte()
+    return 0U.to_byte()
   }
   let b = self.data[self.pos]
   self.pos = self.pos + 1


### PR DESCRIPTION
## Summary
- guard Reader against out-of-bounds byte and slice reads
- ensure partial reads advance the cursor to avoid stalling
- add regression test for short data handling

## Testing
- moon info && moon fmt *(fails: missing registry modules moonbitlang/quickcheck and f4ah6o/encoding_sjis)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695917b293e4832fae73281135caec36)